### PR TITLE
Changes to setup.py and __init__.py to enable Python3 installation. 

### DIFF
--- a/ugradio_code/.gitignore
+++ b/ugradio_code/.gitignore
@@ -1,0 +1,104 @@
+# Other
+.DS_Store
+
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+env/
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+.hypothesis/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# pyenv
+.python-version
+
+# celery beat schedule file
+celerybeat-schedule
+
+# SageMath parsed files
+*.sage.py
+
+# dotenv
+.env
+
+# virtualenv
+.venv
+venv/
+ENV/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/

--- a/ugradio_code/setup.py
+++ b/ugradio_code/setup.py
@@ -1,4 +1,7 @@
-from distutils.core import setup
+try:
+    from setuptools import setup
+except ImportError:
+    from distutils.core import setup
 import glob
 import os
 import sys
@@ -25,7 +28,11 @@ setup_args = {
     'packages': ['ugradio'],
     'include_package_data': True,
     'scripts': glob.glob('scripts/*'),
-    'install_requires': ['astropy>2','numpy','barycorrpy'],
+    'install_requires': [
+        'astropy>2',
+        'numpy',
+        'barycorrpy',
+        'serial'],
     'version': '0.0.1',
     #'package_data': {'ugradio': data_files},
     'zip_safe': False,

--- a/ugradio_code/src/__init__.py
+++ b/ugradio_code/src/__init__.py
@@ -8,5 +8,11 @@ try:
     import gauss # ImportError if scipy not installed
 except(ImportError): pass
 
-import pico, dft, agilent, hp_multi, interf, leusch
-import nch, leo
+from . import pico
+from . import dft
+from . import agilent
+from . import hp_multi
+from . import interf
+from . import leusch
+from . import nch
+from . import leo

--- a/ugradio_code/src/agilent.py
+++ b/ugradio_code/src/agilent.py
@@ -1,6 +1,8 @@
 '''Module for interaction with Agilent N9310a Frequency Synthesizer.'''
 
-import socket, thread
+import socket
+try: import thread
+except(ImportError): import _thread as thread
 
 DEVICE = '/dev/usbtmc0' # default mounting point
 HOST, PORT = '10.32.92.95', 1341
@@ -32,7 +34,7 @@ class SynthBase:
     def set_frequency(self, val, unit):
         '''Set the frequency of the CW (continuous wave) output
         mode of the synthesizer.
-        
+
         Parameters
         ----------
         val  : float, numerical frequency setting
@@ -59,7 +61,7 @@ class SynthBase:
     def set_amplitude(self, val, unit):
         '''Set the amplitude of the CW (continuous wave) output
         mode of the synthesizer.
-        
+
         Parameters
         ----------
         val  : float, numerical amplitude setting
@@ -73,7 +75,7 @@ class SynthBase:
         self._write(cmd)
 
 class SynthDirect(SynthBase):
-    '''Implements a direct connection to the synthesizer via a 
+    '''Implements a direct connection to the synthesizer via a
     USB connection (typically device='/dev/usbtmc0' or similar).'''
     def __init__(self, device=DEVICE):
         '''Parameters
@@ -144,7 +146,8 @@ class SynthServer(SynthDirect):
             s.listen(10)
             while True:
                 conn, addr = s.accept()
-                if self.verbose: print 'Request from ' + addr[0] + ':' + str(addr[1])
+                if self.verbose:
+                    print('Request from ' + addr[0] + ':' + str(addr[1]))
                 if self._device_failure:
                     self._open_device()
                     self._device_failure = False
@@ -156,8 +159,9 @@ class SynthServer(SynthDirect):
         at most one write and one read before terminating connection.'''
         cmd = conn.recv(1024)
         if not cmd: return
-        if self.verbose: print 'Received:', [cmd]
-        try: 
+        if self.verbose:
+            print('Received:', [cmd])
+        try:
             self._write(cmd)
         except(IOError):
             self._device_failure = True

--- a/ugradio_code/src/leusch.py
+++ b/ugradio_code/src/leusch.py
@@ -3,7 +3,9 @@
 """Module for controlling the Leuschner radio telescope."""
 
 from __future__ import print_function
-import socket, serial, time, thread, math
+import socket, serial, time, math
+try: import thread
+except(ImportError): import _thread as thread
 try:
     import RPi.GPIO as GPIO # necessary for LeuschNoiseServer
 except(ImportError):
@@ -392,16 +394,17 @@ class LeuschNoiseServer:
         # only execute digital I/O write code if a change of state
         # command is received over the socket.  I will avoid multiple of
         # overwrite commands to the Raspberry
+        pin = 5 # This was originally 05
         if self.prev_cmd != cmd:
             self.prev_cmd = cmd
             GPIO.setmode(GPIO.BCM) # Errors out if import RPi.GPIO failed
             GPIO.setwarnings(False)
-            GPIO.setup(05, GPIO.OUT) # pin 29
+            GPIO.setup(pin, GPIO.OUT) # pin 29
             # switch pin 29 of Raspberry Pi to TTL level low
             if cmd == CMD_NOISE_OFF:
                 if self.verbose: print('write digital I/O low')
-                GPIO.output(05, False)   # pin 29
+                GPIO.output(pin, False)   # pin 29
             # switch pin 29 of Raspberry Pi to TTL level high
             elif cmd == CMD_NOISE_ON:
                 if self.verbose: print('write digital I/O high')
-                GPIO.output(05, True)   # pin 29
+                GPIO.output(pin, True)   # pin 29


### PR DESCRIPTION
Add .gitignore to avoid committing distribution files. As such, `python setup.py install` works with Python 3.7. 

These changes break the python2 version, however, in terms of dependencies. Some examples:

The most glaring: `astropy` requires Python>=3.5. This is probably the biggest reason to fully migrate.

`thread` works in Python 2 but not in Python 3. If we are only going to fully migrate to Python 3, we may as well just use `threading`.

`serial` is not an included module in Python 3, but including it forces other dependencies in Python 2. #7 