### PR TITLE
Update Pointing Offsets in interf.py

### DIFF
--- a/ugradio_code/src/interf.py
+++ b/ugradio_code/src/interf.py
@@ -124,7 +124,7 @@ HOST_ANT_E = '10.32.92.118' # RPI host for eastern interferometer antenna
 PORT = 1420
 
 # Offsets to subtract from crd to get encoder value to write
-DELTA_ALT_ANT_W = -0.4  # (true - encoder) offset, updated 3/10/25
+DELTA_ALT_ANT_W = -52.0  # (true - encoder) offset, updated 3/10/25
 DELTA_AZ_ANT_W  =  4.5  # (true - encoder) offset, updated 3/08/24
 DELTA_ALT_ANT_E =  0.5  # (true - encoder) offset, updated 2/13/23
 DELTA_AZ_ANT_E  =  0.5  # (true - encoder) offset, updated 2/13/23

--- a/ugradio_code/src/interf.py
+++ b/ugradio_code/src/interf.py
@@ -124,7 +124,7 @@ HOST_ANT_E = '10.32.92.118' # RPI host for eastern interferometer antenna
 PORT = 1420
 
 # Offsets to subtract from crd to get encoder value to write
-DELTA_ALT_ANT_W = -52.0  # (true - encoder) offset, updated 3/10/25
+DELTA_ALT_ANT_W = -52.0  # (true - encoder) offset, updated 4/14/26
 DELTA_AZ_ANT_W  =  4.5  # (true - encoder) offset, updated 3/08/24
 DELTA_ALT_ANT_E =  0.5  # (true - encoder) offset, updated 2/13/23
 DELTA_AZ_ANT_E  =  0.5  # (true - encoder) offset, updated 2/13/23


### PR DESCRIPTION
Fixed pointing offsets due to the issue that happened in lab 3 with the position encoder shaft. Delta_Alt_Ant_W was changed from -0.4 degrees to -52 degrees.